### PR TITLE
fix: execute script mode IF and Python helpers

### DIFF
--- a/custom_components/opengrowbox/OGBController/managers/OGBScriptMode.py
+++ b/custom_components/opengrowbox/OGBController/managers/OGBScriptMode.py
@@ -158,6 +158,9 @@ class OGBScriptMode:
         # IF statement - returns new line number for control flow
         elif line.startswith("IF "):
             return await self._dsl_if(line, variables, lines, current_line)
+
+        elif line == "ELSE":
+            return self._skip_to_matching_endif(lines, current_line)
         
         # CALL statement
         elif line.startswith("CALL "):
@@ -203,9 +206,22 @@ class OGBScriptMode:
                 if block_depth == 0:
                     return i
             elif stmt == "ELSE" and block_depth == 1:
-                return i
+                return i + 1
         
         _LOGGER.warning(f"{self.room}: Unclosed IF block starting at line {current_line + 1}")
+        return len(lines)
+
+    def _skip_to_matching_endif(self, lines: List[str], current_line: int) -> int:
+        """Return the matching ENDIF line for an ELSE branch that should be skipped."""
+        block_depth = 1
+        for i in range(current_line + 1, len(lines)):
+            stmt = lines[i].strip().upper()
+            if stmt.startswith("IF "):
+                block_depth += 1
+            elif stmt == "ENDIF":
+                block_depth -= 1
+                if block_depth == 0:
+                    return i
         return len(lines)
     
     def _eval_expression(self, expr: str, variables: Dict) -> Any:
@@ -264,21 +280,6 @@ class OGBScriptMode:
         self.data_store.setDeep(path, value)
         
         _LOGGER.debug(f"{self.room}: SET {path} = {value}")
-    
-    async def _dsl_if(self, line: str, variables: Dict) -> Optional[int]:
-        """
-        Execute IF statement.
-        Returns None for normal flow, or line number to jump to.
-        """
-        # Simplified IF handling - full implementation would need proper parsing
-        condition = line.replace("IF ", "").replace(" THEN", "").strip()
-        
-        if not self._eval_condition(condition, variables):
-            # Condition false - skip to ENDIF or ELSE
-            # This is simplified - would need proper block handling
-            pass
-        
-        return None
     
     async def _dsl_call(self, line: str, variables: Dict):
         """Execute CALL statement: CALL device.action"""
@@ -381,6 +382,9 @@ class OGBScriptMode:
             )
         except asyncio.TimeoutError:
             _LOGGER.warning(f"{self.room}: Script execution timeout")
+        finally:
+            if hasattr(self, "_python_tasks"):
+                del self._python_tasks
     
     def _is_python_code_safe(self, code: str) -> bool:
         """
@@ -421,8 +425,11 @@ class OGBScriptMode:
         return True
 
     async def _run_python_code(self, code: str, exec_globals: Dict):
-        """Run Python code with globals."""
+        """Run Python code with globals and await queued helper tasks."""
+        self._python_tasks = []
         exec(code, exec_globals)
+        if self._python_tasks:
+            await asyncio.gather(*self._python_tasks)
     
     def _py_read(self, path: str) -> Any:
         """Python helper: Read from DataStore."""
@@ -432,13 +439,15 @@ class OGBScriptMode:
         """Python helper: Write to DataStore."""
         self.data_store.setDeep(path, value)
     
-    async def _py_call(self, device: str, action: str, **kwargs):
-        """Python helper: Call device action."""
-        await self._execute_device_action(device, action, kwargs)
+    def _py_call(self, device: str, action: str, **kwargs):
+        """Python helper: Queue a device action."""
+        task = asyncio.create_task(self._execute_device_action(device, action, kwargs))
+        self._python_tasks.append(task)
     
-    async def _py_emit(self, event: str, data: Dict = None):
-        """Python helper: Emit event."""
-        await self.event_manager.emit(event, data or {})
+    def _py_emit(self, event: str, data: Dict = None):
+        """Python helper: Queue an event emission."""
+        task = asyncio.create_task(self.event_manager.emit(event, data or {}))
+        self._python_tasks.append(task)
     
     def _py_log(self, message: str, level: str = "info"):
         """Python helper: Log message."""

--- a/tests/logic/modes/test_script_mode_logic.py
+++ b/tests/logic/modes/test_script_mode_logic.py
@@ -13,12 +13,20 @@ class _FakeDSManager:
         return self.config
 
 
+class _FakeActionManager:
+    def __init__(self):
+        self.publications = []
+
+    async def checkLimitsAndPublicate(self, publications):
+        self.publications.extend(publications)
+
+
 class _FakeOGB:
-    def __init__(self, config):
+    def __init__(self, config, data=None):
         self.room = "dev_room"
-        self.dataStore = FakeDataStore()
+        self.dataStore = FakeDataStore(data)
         self.eventManager = FakeEventManager()
-        self.actionManager = object()
+        self.actionManager = _FakeActionManager()
         self.data_storeManager = _FakeDSManager(config)
 
 
@@ -57,3 +65,53 @@ async def test_execute_python_path_called(monkeypatch):
 
     assert await mode.execute() is True
     assert called["python"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dsl_if_false_skips_to_else_branch():
+    script = """
+    READ temp FROM sensors.temperature
+    IF temp > 30 THEN
+      EMIT TooHot WITH {'branch': 'if'}
+    ELSE
+      EMIT TempOk WITH {'branch': 'else'}
+    ENDIF
+    """
+    ogb = _FakeOGB({"enabled": True, "type": "dsl", "script": script}, {"sensors": {"temperature": 24}})
+    mode = OGBScriptMode(ogb)
+
+    assert await mode.execute() is True
+
+    assert [event["event_name"] for event in ogb.eventManager.emitted] == ["TempOk"]
+    assert ogb.eventManager.emitted[0]["data"] == {"branch": "else"}
+
+
+@pytest.mark.asyncio
+async def test_python_call_helper_executes_device_action():
+    script = "CALL('exhaust', 'on', priority='high')"
+    ogb = _FakeOGB(
+        {"enabled": True, "type": "python", "script": script},
+        {"capabilities": {"canExhaust": {"state": True}}},
+    )
+    mode = OGBScriptMode(ogb)
+
+    assert await mode.execute() is True
+
+    assert len(ogb.actionManager.publications) == 1
+    action = ogb.actionManager.publications[0]
+    assert action.capability == "canExhaust"
+    assert action.action == "On"
+    assert action.priority == "high"
+
+
+@pytest.mark.asyncio
+async def test_python_emit_helper_executes_event():
+    script = "EMIT('ScriptEvent', {'ok': True})"
+    ogb = _FakeOGB({"enabled": True, "type": "python", "script": script})
+    mode = OGBScriptMode(ogb)
+
+    assert await mode.execute() is True
+
+    assert ogb.eventManager.emitted == [
+        {"event_name": "ScriptEvent", "data": {"ok": True}, "haEvent": False, "debug_type": None}
+    ]


### PR DESCRIPTION
## Summary
- Remove the duplicate stub `_dsl_if` implementation so DSL `IF` blocks use the existing block-aware control-flow handler.
- Skip false DSL branches to the first statement after `ELSE`, and skip `ELSE` bodies after a true branch.
- Queue and await Python-mode `CALL`/`EMIT` helper tasks so plain scripts like `CALL(...)` and `EMIT(...)` actually execute.
- Add regression coverage for DSL `IF`/`ELSE`, Python `CALL`, and Python `EMIT`.

Fixes #50.

## Test plan
- [x] Confirmed new regression tests failed before the implementation:
  - `test_dsl_if_false_skips_to_else_branch`
  - `test_python_call_helper_executes_device_action`
  - `test_python_emit_helper_executes_event`
- [x] `python3 -m pytest tests/logic/modes/test_script_mode_logic.py -q` — 6 passed
- [x] `python3 -m pytest tests/logic/modes -q` — 76 passed, 4 existing warnings
- [x] `python3 -m pytest tests/logic -q` — 563 passed, 1 skipped, 20 existing warnings
- [x] `python3 -m py_compile custom_components/opengrowbox/OGBController/managers/OGBScriptMode.py tests/logic/modes/test_script_mode_logic.py`
- [x] `git diff --check`
